### PR TITLE
xcode does not install gcc, it installs clang

### DIFF
--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -37,7 +37,7 @@ You'll need the following tools:
     - **Note**: Building and debugging via the Windows subsystem for Linux (WSL) is currently not supported.
 
   - **macOS**
-    - [Xcode](https://developer.apple.com/xcode/downloads/) and the Command Line Tools, which will install `gcc` and the related toolchain containing `make`
+    - [Xcode](https://developer.apple.com/xcode/downloads/) and the Command Line Tools, which will install `clang` and the related toolchain containing `make`
       - Run `xcode-select --install` to install the Command Line Tools
   - **Linux**
     * `make`


### PR DESCRIPTION
`gcc` is just an alias for `clang`

```
gcc --version
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/4.2.1
Apple clang version 11.0.3 (clang-1103.0.32.62)
Target: x86_64-apple-darwin19.5.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```